### PR TITLE
Adding cosmos_dbs to the caf_mlops landingzone

### DIFF
--- a/landingzones/caf_mlops/landingzone.tf
+++ b/landingzones/caf_mlops/landingzone.tf
@@ -20,7 +20,7 @@ module "mlops" {
 
   database = {
     machine_learning_workspaces = var.machine_learning_workspaces
-    cosmos_dbs = var.cosmos_dbs
+    cosmos_dbs                   = var.cosmos_dbs
   }
 
   compute = {

--- a/landingzones/caf_mlops/output.tf
+++ b/landingzones/caf_mlops/output.tf
@@ -46,3 +46,8 @@ output azure_container_registries {
   value     = module.mlops.azure_container_registries
   sensitive = true
 }
+
+output cosmos_dbs {
+  value     = module.mlops.cosmos_dbs
+  sensitive = true
+}


### PR DESCRIPTION
## Description

Adding cosmos output attributes exported from Terraform's cosmos provider to the caf_mlops landingzone

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Testing

Validated that I was able to create a keyvault secret containing the cosmos connection string sourced from this exported dataset. 
