### PR TITLE
Adding App Config to the mlops LZ

### DIFF
--- a/landingzones/caf_foundations/main.tf
+++ b/landingzones/caf_foundations/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.40.0"
+      version = "2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/landingzones/caf_launchpad/main.tf
+++ b/landingzones/caf_launchpad/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.40.0"
+      version = "2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/landingzones/caf_mlops/landingzone.tf
+++ b/landingzones/caf_mlops/landingzone.tf
@@ -20,7 +20,7 @@ module "mlops" {
 
   database = {
     machine_learning_workspaces = var.machine_learning_workspaces
-    cosmos_dbs = var.cosmos_dbs
+    cosmos_dbs                   = var.cosmos_dbs
   }
 
   compute = {

--- a/landingzones/caf_mlops/landingzone.tf
+++ b/landingzones/caf_mlops/landingzone.tf
@@ -37,6 +37,7 @@ module "mlops" {
 
   remote_objects = {
     azuread_groups                   = local.remote.azuread_groups
+    machine_learning_workspaces      = local.remote.machine_learning_workspaces
     managed_identities               = local.remote.managed_identities
     vnets                            = local.remote.vnets
     azurerm_firewalls                = local.remote.azurerm_firewalls

--- a/landingzones/caf_mlops/landingzone.tf
+++ b/landingzones/caf_mlops/landingzone.tf
@@ -20,7 +20,8 @@ module "mlops" {
 
   database = {
     machine_learning_workspaces = var.machine_learning_workspaces
-    cosmos_dbs                   = var.cosmos_dbs
+    cosmos_dbs                  = var.cosmos_dbs
+    app_config                  = var.app_config
   }
 
   compute = {

--- a/landingzones/caf_mlops/locals.remote_tfstates.tf
+++ b/landingzones/caf_mlops/locals.remote_tfstates.tf
@@ -43,6 +43,9 @@ locals {
   }
 
   remote = {
+    machine_learning_workspaces = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.ml_workspace[key], {}))
+    }
     managed_identities = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.managed_identities[key], {}))
     }
@@ -74,6 +77,7 @@ locals {
 
 
   combined = {
+    machine_learning_workspaces      = merge(local.remote.machine_learning_workspaces, map(var.landingzone.key, module.mlops.machine_learning_workspaces))
     managed_identities               = merge(local.remote.managed_identities, map(var.landingzone.key, module.mlops.managed_identities))
     vnets                            = merge(local.remote.vnets, map(var.landingzone.key, module.mlops.vnets))
     azurerm_firewalls                = merge(local.remote.azurerm_firewalls, map(var.landingzone.key, module.mlops.azurerm_firewalls))

--- a/landingzones/caf_mlops/main.tf
+++ b/landingzones/caf_mlops/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.40.0"
+      version = "~> 2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/landingzones/caf_mlops/output.tf
+++ b/landingzones/caf_mlops/output.tf
@@ -51,3 +51,8 @@ output cosmos_dbs {
   value     = module.mlops.cosmos_dbs
   sensitive = true
 }
+
+output app_config {
+  value     = module.mlops.app_config
+  sensitive = true
+}

--- a/landingzones/caf_mlops/output.tf
+++ b/landingzones/caf_mlops/output.tf
@@ -46,3 +46,8 @@ output azure_container_registries {
   value     = module.mlops.azure_container_registries
   sensitive = true
 }
+
+output cosmos_dbs {
+  value     = module.mlops.cosmos_dbs
+  sensitive = true
+}

--- a/landingzones/caf_mlops/readme.md
+++ b/landingzones/caf_mlops/readme.md
@@ -6,6 +6,7 @@ The mlops landing zone allows you to deploy a simple machine learning workspace 
 * App insights
 * Key Vault
 * Storage Account
+* Application Configuration
 
 MLOps landing zone operates at **level 3**.
 

--- a/landingzones/caf_mlops/variables.tf
+++ b/landingzones/caf_mlops/variables.tf
@@ -123,3 +123,7 @@ variable azure_container_registries {
 variable dynamic_keyvault_secrets {
   default = {}
 }
+
+variable app_config {
+  default = {}
+}

--- a/landingzones/caf_networking/main.tf
+++ b/landingzones/caf_networking/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.40.0"
+      version = "2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/landingzones/caf_shared_services/main.tf
+++ b/landingzones/caf_shared_services/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.40.0"
+      version = "2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/landingzones/common_landingzone/main.tf
+++ b/landingzones/common_landingzone/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.40.0"
+      version = "~> 2.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
## PR Checklist

---
## Description
This feature request includes the following changes: 
- Adding the application config module to the caf_mlops landingzone 
- Adding `machine_learning_workspaces` to the mlops remote outputs so we can reference the AML MSI principal ID. 

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Testing

Verified that I was able to provision an app configuration resource using this landingzone
